### PR TITLE
memcache_pycompat: python2 / python3 and go compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,12 @@
 module github.com/jehiah/memcache_pycompat
 
-go 1.13
+go 1.20
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/dgryski/dgohash v0.0.0-20181015193854-bc94635621ad
+	github.com/nlpodyssey/gopickle v0.3.0
 	github.com/rckclmbr/goketama v0.0.0-20181103001945-ac3ec91389c8
 )
+
+require golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,9 @@ github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b h1:L/QXpzIa3pO
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/dgryski/dgohash v0.0.0-20181015193854-bc94635621ad h1:y+KtPFl9r8KnMm2Xb3jtVujm4Js3PhYLQ5qPLsyZl0Y=
 github.com/dgryski/dgohash v0.0.0-20181015193854-bc94635621ad/go.mod h1:5U7QOv6DFpngdeuj14yOvsehDGUGJSr9XPmYHdH097M=
+github.com/nlpodyssey/gopickle v0.3.0 h1:BLUE5gxFLyyNOPzlXxt6GoHEMMxD0qhsE4p0CIQyoLw=
+github.com/nlpodyssey/gopickle v0.3.0/go.mod h1:f070HJ/yR+eLi5WmM1OXJEGaTpuJEUiib19olXgYha0=
 github.com/rckclmbr/goketama v0.0.0-20181103001945-ac3ec91389c8 h1:cdqAI4nMyogkHOpUo+T/Gowz+B+20R9W/yzhKTFVp9Y=
 github.com/rckclmbr/goketama v0.0.0-20181103001945-ac3ec91389c8/go.mod h1:36E0jqCK+H1LXGERfZkLAymw60mJiZoK3nbSFpzgKPo=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/memcache_test.go
+++ b/memcache_test.go
@@ -1,8 +1,11 @@
 package memcache
 
 import (
+	"strconv"
 	"testing"
 	"time"
+
+	"github.com/bradfitz/gomemcache/memcache"
 )
 
 func TestGetSet(t *testing.T) {
@@ -17,12 +20,87 @@ func TestGetSet(t *testing.T) {
 	u := "Iñtërnâtiôn�lizætiøn"
 	mc.Set(UnicodeItem("unicode", u))
 	if v, ok := mc.GetString("unicode"); !ok || v != u {
-		t.Errorf("did't get unicode string back %v", v)
+		t.Errorf("didn't get unicode string back %v", v)
 	}
 
 	mc.Set(StringItem("str", u))
 	if v, ok := mc.GetString("str"); !ok || v != u {
-		t.Errorf("did't get string back %v", v)
+		t.Errorf("didn't get string back %v", v)
+	}
+
+	mc.Set(BoolItem("boolean", true))
+	if v, ok := mc.GetBool("boolean"); !ok || v != true {
+		t.Errorf("Expected true, got: %v", v)
+	}
+}
+
+func TestItem_String(t *testing.T) {
+	mc := NewClient([]string{"127.0.0.1:11211"})
+
+	manualPickledItem := &memcache.Item{
+		Key:   "manually_pickled",
+		Value: []byte("\x80\x02X\x1c\x00\x00\x00I\xc3\xb1t\xc3\xabrn\xc3\xa2ti\xc3\xb4n\xef\xbf\xbdliz\xc3\xa6ti\xc3\xb8nq\x00."),
+		Flags: FLAG_NONE,
+	}
+	mc.Set(manualPickledItem)
+	if mpi, ok := mc.GetString("manually_pickled"); !ok || mpi != "Iñtërnâtiôn�lizætiøn" {
+		t.Errorf("Expected Iñtërnâtiôn�lizætiøn, got: %v", mpi)
+	}
+
+	pickledItem := &memcache.Item{
+		Key:   "pickled",
+		Value: []byte("\x80\x02X\x1c\x00\x00\x00I\xc3\xb1t\xc3\xabrn\xc3\xa2ti\xc3\xb4n\xef\xbf\xbdliz\xc3\xa6ti\xc3\xb8nq\x00."),
+		Flags: FLAG_PICKLE,
+	}
+	mc.Set(pickledItem)
+	if pi, ok := mc.GetString("pickled"); !ok || pi != "Iñtërnâtiôn�lizætiøn" {
+		t.Errorf("Expected Iñtërnâtiôn�lizætiøn, got: %v", pi)
+	}
+
+	unicodeItem := UnicodeItem("unicode", "Iñtërnâtiôn�lizætiøn")
+	mc.Set(unicodeItem)
+	if u, ok := mc.GetString("unicode"); !ok || u != "Iñtërnâtiôn�lizætiøn" {
+		t.Errorf("Expected Iñtërnâtiôn�lizætiøn, got: %v", u)
+	}
+
+	item := StringItem("string", "Iñtërnâtiôn�lizætiøn")
+	mc.Set(item)
+	if i, ok := mc.GetString("string"); !ok || i != "Iñtërnâtiôn�lizætiøn" {
+		t.Errorf("Expected Iñtërnâtiôn�lizætiøn, got: %v", i)
+	}
+
+	invalidItem := &memcache.Item{
+		Key:   "invalid",
+		Value: []byte("invalid"),
+		Flags: FLAG_PICKLE,
+	}
+	mc.Set(invalidItem)
+	if _, ok := mc.GetString("invalid"); ok {
+		t.Errorf("Expected invalid, got: %v", ok)
+	}
+}
+
+func TestItem_Int64(t *testing.T) {
+	mc := NewClient([]string{"127.0.0.1:11211"})
+
+	long := &memcache.Item{
+		Key:   "long",
+		Value: []byte(strconv.FormatInt(int64(1234567890), 10)),
+		Flags: FLAG_LONG,
+	}
+	mc.Set(long)
+	if l, ok := mc.GetInt64("long"); !ok || l != 1234567890 {
+		t.Errorf("Expected 1234567890, got: %v", l)
+	}
+
+	int := &memcache.Item{
+		Key:   "int",
+		Value: []byte(strconv.FormatInt(int64(1234567890), 10)),
+		Flags: FLAG_INTEGER,
+	}
+	mc.Set(int)
+	if l, ok := mc.GetInt64("int"); !ok || l != 1234567890 {
+		t.Errorf("Expected 1234567890, got: %v", l)
 	}
 
 }


### PR DESCRIPTION
This creates compatibility between `pylibmc==1.5.2` and `gomemcache` for Python 2 and Python 3 and emulates previous functionality for python 2.

### Steps
* [ ] merge
* [ ] release 1.1.0 

---
The upgrade to Python 3 introduced new pickle protocol versions. Previously only protocol version 2 was supported. More information found here:
https://docs.python.org/3/library/pickle.html#data-stream-format

For Python 2.7 and Python 3 support, we can use an external package `gopickle` that can unpickle protocol versions 0 - 5 which would provide ways in the future to unpickle different protocol versions. However, keep in mind that pylibmc in python2 can only support protocol versions up to 2. 

On the pylibmc side, a wrapper is used to enforce pickle version 2 for python3+.

When python2 becomes unsupported, the manual checks for pickling can be omitted. 